### PR TITLE
clear interrupt flag before latch.await in trigger shutdown

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3746,6 +3746,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             final java.util.Timer timer = Trigger.timer;
             if (timer != null) {
                 final CountDownLatch latch = new CountDownLatch(1);
+                // before starting the wait, clear possible latent interrupt flag,
+                // otherwise latch.await may immediately throw an InterruptedException
+                if (Thread.interrupted()) {
+                    LOGGER.log(Level.FINE, "Cleared interrupt flag before trigger shutdown");
+                }
                 timer.schedule(new TimerTask() {
                     @Override
                     public void run() {


### PR DESCRIPTION
A latent interrupt flag set before we call `latch.await` will immediately throw an error when we call the await function.
It is better to discard this interrupt flag if it was set before we start `latch.await`. 

This way the await can still be interrupted, but only if the interrupt is called on its thread _after_ the await actually began.

It is unclear why but in our case this interrupt flag is set sometimes at the time `_cleanUpShutdownTriggers` is invoked; When it is set jenkins will fail to shutdown and it exits with a non-zero code instead (the InterruptedException bubbles up and causes a non-zero exit code). In my opinion it is preferable to ignore such a pre-set interrupt flag. As mentioned above, when there is a valid case for interrupting, it can still be done while the latch is waiting.

Realistic tests would be difficult to add as we also cannot reproduce it reliably in our environment. Also the 3 lines of additional code are fairly self evident.

--------------------------------

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Clear the interrupt flag in the cleanUp thread before starting the shutdown of triggers during a jenkins shutdown

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
